### PR TITLE
feat: add persistent Codex tmux workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Workspace Setup
 
-Automated workspace setup script for Ubuntu, macOS, and Amazon Linux 2023. Sets up a development environment with zsh, Prezto, and essential development tools.
+Automated workspace setup script for Ubuntu, macOS, and Amazon Linux 2023. Sets up a development environment with zsh, Prezto, persistent tmux sessions, and essential development tools.
 
 ## Features
 
@@ -21,9 +21,11 @@ Automated workspace setup script for Ubuntu, macOS, and Amazon Linux 2023. Sets 
   - Python 3.12 (via mise)
   - Node.js 24 (via mise)
   - Bun (via mise)
+  - tmux with Oh My Tmux
   - VS Code with extensions bundle
   - Gemini CLI
   - Claude Code CLI
+  - OpenAI Codex CLI with persistent per-project tmux sessions
 
 - **macOS Only**:
   - OpenSuperWhisper
@@ -39,7 +41,7 @@ Automated workspace setup script for Ubuntu, macOS, and Amazon Linux 2023. Sets 
 ## Quick Start
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/workspacesetup.git
+git clone https://github.com/rsaiprasad/workspacesetup.git
 cd workspacesetup
 chmod +x setup.sh
 ./setup.sh
@@ -73,11 +75,13 @@ chmod +x setup.sh
 - **mise**: Runtime version manager (replaces asdf, nvm, pyenv)
 - **Python**: Latest version via mise
 - **Node.js**: LTS version via mise
+- **tmux**: Persistent terminal sessions with Oh My Tmux
 - **VS Code**: Code editor with Cline extension
 
 ### CLI Tools
 - **Gemini CLI**: Google's AI assistant
 - **Claude Code CLI**: Anthropic's AI coding assistant
+- **Codex CLI**: OpenAI's coding assistant, wrapped in tmux for interactive use
 
 ### Applications
 - **Google Chrome**: Web browser
@@ -108,7 +112,49 @@ eval "$(mise activate zsh)"
 # Install CLIs
 npm install -g @google/gemini-cli
 npm install -g @anthropic-ai/claude-code
+
+# Install Codex CLI on macOS or Linux
+curl -fsSL https://chatgpt.com/codex/install.sh | sh
 ```
+
+## Codex Sessions with tmux
+
+In the configured zsh shell, interactive `codex` commands automatically create or attach to a tmux session named after the current Git repository, such as `codex-stockstudy-123456789`. The numeric suffix comes from the full repository path, so repositories with the same directory name remain separate. The same session is available from a local terminal or over SSH.
+
+```bash
+cd ~/workspace/stockstudy
+codex
+```
+
+To detach without stopping Codex, press `Ctrl-b`, then `d`. From another terminal or SSH connection, return to the same repository and run `codex` again. The active session is handed over to the new terminal.
+
+Useful commands:
+
+```bash
+# List active tmux sessions
+tmux ls
+
+# Attach explicitly and detach its old client (copy the name from `tmux ls`)
+tmux attach -d -t codex-stockstudy-123456789
+
+# Start another Codex session for the same repository
+CODEX_TMUX_SESSION=codex-stockstudy-2 codex
+
+# Run Codex without the tmux wrapper
+CODEX_TMUX_BYPASS=1 codex
+```
+
+Different repositories automatically receive different session names. Inside tmux, press `Ctrl-b`, then `c` to open another window; running `codex` there starts another Codex process without nesting tmux. When attaching to an existing session, that session's running Codex process is kept and new CLI arguments are ignored.
+
+Non-TTY commands, such as normal scripts and CI jobs, run Codex directly. The setup does not force every SSH login into tmux, and it does not change project-specific model routing or instructions.
+
+tmux sessions survive terminal closures and SSH disconnects, but not a machine reboot. After restarting, return to the project and resume the most recent saved Codex conversation:
+
+```bash
+codex resume --last
+```
+
+See the [official Codex CLI guide](https://developers.openai.com/codex/cli/) and [CLI reference](https://developers.openai.com/codex/cli/reference/).
 
 ## Customization
 

--- a/configs/codex-tmux
+++ b/configs/codex-tmux
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+codex_bin="${CODEX_REAL_BIN:-$(type -P codex || true)}"
+
+if [[ -z "$codex_bin" || ! -x "$codex_bin" ]]; then
+    printf 'codex-tmux: Codex CLI was not found.\n' >&2
+    printf 'Install Codex or set CODEX_REAL_BIN to its executable.\n' >&2
+    exit 127
+fi
+
+# Avoid nested tmux sessions and preserve normal behavior for scripts and CI.
+if [[ -n "${TMUX:-}" || "${CODEX_TMUX_BYPASS:-0}" == "1" || ! -t 0 || ! -t 1 ]]; then
+    exec "$codex_bin" "$@"
+fi
+
+tmux_bin="${TMUX_BIN:-$(type -P tmux || true)}"
+if [[ -z "$tmux_bin" || ! -x "$tmux_bin" ]]; then
+    printf 'codex-tmux: tmux was not found.\n' >&2
+    exit 127
+fi
+
+workspace_root=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")
+workspace_name=$(basename "$workspace_root")
+workspace_slug=$(printf '%s' "$workspace_name" | tr -cs '[:alnum:]_-' '-' | sed -E 's/^-+//; s/-+$//')
+if [[ -z "$workspace_slug" ]]; then
+    workspace_slug="workspace"
+fi
+workspace_id=$(printf '%s' "$workspace_root" | cksum | awk '{print $1}')
+
+session_name="${CODEX_TMUX_SESSION:-codex-$workspace_slug-$workspace_id}"
+
+# Create or attach to the project session. -D hands an existing session from an
+# old local/SSH client to this terminal. Existing sessions keep their running
+# Codex process, so arguments supplied during a reattach are intentionally ignored.
+exec "$tmux_bin" new-session -A -D -s "$session_name" -c "$PWD" -n codex "$codex_bin" "$@"

--- a/configs/codex-tmux.zsh
+++ b/configs/codex-tmux.zsh
@@ -1,0 +1,4 @@
+# Keep interactive Codex CLI work in a stable tmux session per Git repository.
+codex() {
+    "$HOME/.local/bin/codex-tmux" "$@"
+}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -124,6 +124,64 @@ configure_tmux() {
     fi
 }
 
+install_codex_cli() {
+    export PATH="$HOME/.local/bin:$PATH"
+
+    if command -v codex &> /dev/null; then
+        echo "Codex CLI is already installed"
+        codex --version
+        return
+    fi
+
+    echo "Installing Codex CLI..."
+    local installer
+    installer=$(mktemp "${TMPDIR:-/tmp}/codex-install.XXXXXX")
+
+    if ! curl -fsSL https://chatgpt.com/codex/install.sh -o "$installer"; then
+        rm -f "$installer"
+        echo "Failed to download the Codex CLI installer"
+        return 1
+    fi
+
+    if ! CODEX_NON_INTERACTIVE=1 sh "$installer"; then
+        rm -f "$installer"
+        echo "Codex CLI installation failed"
+        return 1
+    fi
+    rm -f "$installer"
+
+    hash -r
+    if ! command -v codex &> /dev/null; then
+        echo "Codex CLI installed, but codex is not available in PATH"
+        return 1
+    fi
+
+    codex --version
+}
+
+configure_codex_tmux() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    local config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/workspacesetup"
+    local zshrc="${ZDOTDIR:-$HOME}/.zshrc"
+    local source_line='source "${XDG_CONFIG_HOME:-$HOME/.config}/workspacesetup/codex-tmux.zsh"'
+
+    mkdir -p "$HOME/.local/bin" "$config_dir" "$(dirname "$zshrc")"
+    install -m 0755 "$script_dir/configs/codex-tmux" "$HOME/.local/bin/codex-tmux"
+    install -m 0644 "$script_dir/configs/codex-tmux.zsh" "$config_dir/codex-tmux.zsh"
+
+    touch "$zshrc"
+    if ! grep -Fq 'workspacesetup/codex-tmux.zsh' "$zshrc" 2>/dev/null; then
+        printf '\n# Start interactive Codex CLI work in persistent tmux sessions.\n%s\n' \
+            "$source_line" >> "$zshrc"
+        echo "Codex tmux integration added to .zshrc"
+    else
+        echo "Codex tmux integration is already in .zshrc"
+    fi
+
+    echo "Codex tmux wrapper deployed"
+}
+
 set_default_editor() {
     echo "Setting default editor to vi..."
     git config --global core.editor "vi"

--- a/setup.sh
+++ b/setup.sh
@@ -85,7 +85,9 @@ fi
 run_step gnupg          "Installing GnuPG"                        install_gnupg
 run_step mise           "Installing mise"                         install_mise
 run_step languages      "Installing Python, Node.js, and Bun via mise" install_languages
+run_step codex_cli      "Installing Codex CLI"                    install_codex_cli
 run_step tmux           "Installing tmux with Oh My Tmux"         install_tmux
+run_step codex_tmux     "Configuring persistent Codex sessions"   configure_codex_tmux
 run_step vscode         "Installing VS Code"                      install_vscode
 run_step vscode_ext     "Installing VS Code Extensions"           install_vscode_extensions
 run_step cline          "Installing Cline Extension"              install_cline_extension


### PR DESCRIPTION
## Summary

- install the OpenAI Codex CLI with the official standalone installer
- route interactive Codex sessions through stable, per-repository tmux sessions
- preserve direct behavior inside tmux, scripts, and CI
- document local/SSH reattachment, multiple sessions, bypass mode, and reboot recovery

## Verification

- `bash -n setup.sh scripts/common.sh scripts/ubuntu.sh scripts/macos.sh scripts/amzn.sh configs/codex-tmux`
- `zsh -n configs/codex-tmux.zsh`
- `git diff --check`
- verified idempotent setup with default and custom `ZDOTDIR`
- verified non-TTY, nested-tmux, explicit-bypass, quoted-argument, and interactive routing paths
- verified a real tmux session survives `Ctrl-b d`
- verified same-named repositories receive distinct session names