### PR TITLE
Fix Ubuntu terminal Nerd Font setup

### DIFF
--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -1,0 +1,17 @@
+name: Shell tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ubuntu-terminal-font:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check shell syntax
+        run: bash -n setup.sh scripts/*.sh tests/*.sh
+      - name: Test Ubuntu terminal font setup
+        run: bash tests/ubuntu_terminal_font_test.sh
+      - name: Verify official Meslo archive and font metadata
+        run: bash tests/ubuntu_terminal_font_integration_test.sh

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Automated workspace setup script for Ubuntu, macOS, and Amazon Linux 2023. Sets 
 
 - **Ubuntu Only**:
   - Terminator terminal with Solarized Dark theme
+  - GNOME Terminal configured with a fixed-width Nerd Font
 
 - **Amazon Linux 2023 Notes**:
   - Uses dnf package manager
@@ -46,6 +47,9 @@ cd workspacesetup
 chmod +x setup.sh
 ./setup.sh
 ```
+
+Run the script as your normal desktop user, not with `sudo`; it invokes `sudo`
+only for the individual system packages that require it.
 
 ## Requirements
 
@@ -67,8 +71,8 @@ chmod +x setup.sh
    - History substring search
 
 ### Fonts
-- Powerline fonts
-- MesloLGS Nerd Font (for terminal theme compatibility)
+- MesloLGS Nerd Font with Powerline glyphs
+- Fixed-width MesloLGS Nerd Font Mono on Ubuntu
 
 ### Development Tools
 - **Git**: Version control
@@ -97,9 +101,17 @@ After running the setup script:
 
 ### Terminal Font Configuration
 
-If you see broken characters in your prompt, set your terminal font to:
-- **MesloLGS NF** or
-- **Meslo LG Nerd Font**
+On Ubuntu, setup installs the fixed-width `MesloLGS Nerd Font Mono` family and
+configures both GNOME Terminal and Terminator to use it. The exact family name
+matters: the non-Mono build can cause excessive character spacing, while an
+unpatched system font renders Prezto's Powerline glyphs incorrectly.
+
+The Ubuntu installer uses the checksum-verified Meslo archive from the
+[official Nerd Fonts releases](https://github.com/ryanoasis/nerd-fonts/releases).
+
+If GNOME Terminal was open while setup ran, save your terminal work, close
+every GNOME Terminal window, and relaunch it. Opening only a new tab is not
+enough because all tabs can share the existing terminal server process.
 
 ### Manual CLI Installation
 
@@ -171,10 +183,16 @@ Edit `~/.config/terminator/config` to customize colors and settings.
 ### Fonts not displaying correctly
 ```bash
 # Ubuntu
-fc-cache -fv
+/usr/bin/fc-match 'MesloLGS Nerd Font Mono'
+printf '\uE0A0 branch  \uE0B0 separator  \uE0B2 reverse  \u276F prompt\n'
 
 # macOS - fonts should auto-reload
 ```
+
+The Ubuntu font match should report `MesloLGS Nerd Font Mono`. If the glyphs
+remain wrong, fully quit and relaunch GNOME Terminal so it rebuilds its font
+map. When connected over SSH, the local terminal still controls glyph
+rendering, so install and select a compatible Nerd Font on the client machine.
 
 ### mise not found after install
 ```bash

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -2,6 +2,49 @@
 
 # Ubuntu-specific installation functions
 
+MESLO_NERD_FONT_VERSION="3.5.0"
+MESLO_NERD_FONT_ARCHIVE_SHA256="24cfe8148aeb600891f1d81180e77ecc967a814cde75dc7e63ec5bc2b0ab3eef"
+MESLO_NERD_FONT_FAMILY="MesloLGS Nerd Font Mono"
+
+WORKSPACE_SETUP_FC_CACHE="${WORKSPACE_SETUP_FC_CACHE:-/usr/bin/fc-cache}"
+WORKSPACE_SETUP_FC_MATCH="${WORKSPACE_SETUP_FC_MATCH:-/usr/bin/fc-match}"
+WORKSPACE_SETUP_FC_SCAN="${WORKSPACE_SETUP_FC_SCAN:-/usr/bin/fc-scan}"
+WORKSPACE_SETUP_GSETTINGS="${WORKSPACE_SETUP_GSETTINGS:-/usr/bin/gsettings}"
+WORKSPACE_SETUP_SYSTEMCTL="${WORKSPACE_SETUP_SYSTEMCTL:-/usr/bin/systemctl}"
+
+meslo_nerd_font_mono_installed() {
+    local fonts_dir="$HOME/.local/share/fonts/MesloLGSNerdFontMono"
+    local font_details
+    local codepoint
+    local style
+
+    [[ -x "$WORKSPACE_SETUP_FC_MATCH" && -x "$WORKSPACE_SETUP_FC_SCAN" ]] || return 1
+
+    for style in Regular Bold Italic BoldItalic; do
+        [[ -s "$fonts_dir/MesloLGSNerdFontMono-${style}.ttf" ]] || return 1
+        font_details=$("$WORKSPACE_SETUP_FC_SCAN" --format='%{family[0]}|%{spacing}' \
+            "$fonts_dir/MesloLGSNerdFontMono-${style}.ttf") || return 1
+        [[ "$font_details" == "$MESLO_NERD_FONT_FAMILY|100" ]] || return 1
+    done
+
+    for codepoint in e0a0 e0b0 e0b2 276f; do
+        font_details=$("$WORKSPACE_SETUP_FC_MATCH" --format='%{family[0]}|%{spacing}' \
+            "$MESLO_NERD_FONT_FAMILY:charset=$codepoint") || return 1
+        [[ "$font_details" == "$MESLO_NERD_FONT_FAMILY|100" ]] || return 1
+    done
+}
+
+migrate_terminator_font_name() {
+    local terminator_config="$HOME/.config/terminator/config"
+
+    if [[ -f "$terminator_config" ]] && \
+       grep -Fqx '    font = MesloLGS NF 11' "$terminator_config"; then
+        sed -i 's/^    font = MesloLGS NF 11$/    font = MesloLGS Nerd Font Mono 11/' \
+            "$terminator_config"
+        echo "Terminator font migrated to $MESLO_NERD_FONT_FAMILY"
+    fi
+}
+
 install_homebrew() {
     if ! command -v brew &> /dev/null; then
         echo "Installing Homebrew..."
@@ -95,32 +138,131 @@ install_prezto() {
 }
 
 install_powerline_fonts() {
-    local fonts_dir="$HOME/.local/share/fonts"
+    local fonts_dir="$HOME/.local/share/fonts/MesloLGSNerdFontMono"
+    local archive_url="https://github.com/ryanoasis/nerd-fonts/releases/download/v${MESLO_NERD_FONT_VERSION}/Meslo.tar.xz"
+    local staging_dir
+    local temp_dir
+    local style
 
-    if dpkg -s fonts-powerline &>/dev/null && [[ -f "$fonts_dir/MesloLGS NF Regular.ttf" ]]; then
-        echo "Powerline fonts already installed"
+    if meslo_nerd_font_mono_installed; then
+        echo "$MESLO_NERD_FONT_FAMILY is already installed"
         return
     fi
 
-    echo "Installing Powerline fonts..."
+    echo "Installing $MESLO_NERD_FONT_FAMILY v${MESLO_NERD_FONT_VERSION}..."
     sudo apt-get update
-    sudo apt-get install -y fonts-powerline
+    sudo apt-get install -y ca-certificates curl fontconfig xz-utils
 
-    mkdir -p "$fonts_dir"
-    if [[ ! -f "$fonts_dir/MesloLGS NF Regular.ttf" ]]; then
-        echo "Installing MesloLGS Nerd Font..."
-        cd /tmp
-        curl -fLo "MesloLGS NF Regular.ttf" \
-            "https://github.com/romkatv/powerlevel10k-media/raw/master/MesloLGS%20NF%20Regular.ttf" 2>/dev/null || true
-        curl -fLo "MesloLGS NF Bold.ttf" \
-            "https://github.com/romkatv/powerlevel10k-media/raw/master/MesloLGS%20NF%20Bold.ttf" 2>/dev/null || true
-        curl -fLo "MesloLGS NF Italic.ttf" \
-            "https://github.com/romkatv/powerlevel10k-media/raw/master/MesloLGS%20NF%20Italic.ttf" 2>/dev/null || true
-        curl -fLo "MesloLGS NF Bold Italic.ttf" \
-            "https://github.com/romkatv/powerlevel10k-media/raw/master/MesloLGS%20NF%20Bold%20Italic.ttf" 2>/dev/null || true
+    temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/meslo-nerd-font.XXXXXX")
+    if ! (
+        set -e
+        trap 'rm -rf -- "$temp_dir"' EXIT
 
-        mv MesloLGS*.ttf "$fonts_dir/" 2>/dev/null || true
-        fc-cache -fv
+        curl --fail --location --retry 3 \
+            --output "$temp_dir/Meslo.tar.xz" "$archive_url" || exit 1
+        printf '%s  %s\n' "$MESLO_NERD_FONT_ARCHIVE_SHA256" "$temp_dir/Meslo.tar.xz" \
+            | sha256sum --check --status || exit 1
+
+        staging_dir="$temp_dir/install"
+        mkdir -p "$staging_dir" || exit 1
+        for style in Regular Bold Italic BoldItalic; do
+            tar -xf "$temp_dir/Meslo.tar.xz" -C "$temp_dir" \
+                "MesloLGSNerdFontMono-${style}.ttf" || exit 1
+            install -m 0644 "$temp_dir/MesloLGSNerdFontMono-${style}.ttf" \
+                "$staging_dir/" || exit 1
+        done
+
+        # Only replace the installed set after every face has downloaded and
+        # extracted successfully, so a failed repair leaves the old set intact.
+        mkdir -p "$fonts_dir" || exit 1
+        install -m 0644 "$staging_dir"/*.ttf "$fonts_dir/" || exit 1
+    ); then
+        echo "Failed to download or install $MESLO_NERD_FONT_FAMILY" >&2
+        return 1
+    fi
+
+    "$WORKSPACE_SETUP_FC_CACHE" -f "$HOME/.local/share/fonts"
+    if ! meslo_nerd_font_mono_installed; then
+        echo "Failed to install the exact font family: $MESLO_NERD_FONT_FAMILY" >&2
+        return 1
+    fi
+
+    UBUNTU_TERMINAL_FONT_FILES_CHANGED=1
+    echo "$MESLO_NERD_FONT_FAMILY installed and verified"
+}
+
+configure_ubuntu_terminal_font() {
+    local current_font
+    local current_use_system_font
+    local font_size="12"
+    local profile_id
+    local profile_schema
+    local configured_font
+    local profile_changed=0
+
+    if ! meslo_nerd_font_mono_installed; then
+        install_powerline_fonts || return 1
+    fi
+
+    # Migrate only the exact legacy value written by older versions of this
+    # repository; leave user-selected Terminator fonts untouched.
+    migrate_terminator_font_name
+
+    if [[ -n "${SSH_CONNECTION:-}${SSH_TTY:-}" ]]; then
+        echo "SSH session detected; skipping GNOME Terminal configuration"
+        return
+    fi
+
+    if [[ ! -x "$WORKSPACE_SETUP_GSETTINGS" ]] || [[ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]] || \
+       [[ -z "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]]; then
+        echo "Local GNOME desktop session not detected; skipping GNOME Terminal configuration"
+        return
+    fi
+
+    if ! "$WORKSPACE_SETUP_GSETTINGS" list-schemas | grep -Fxq 'org.gnome.Terminal.ProfilesList'; then
+        echo "GNOME Terminal is not installed; skipping its profile configuration"
+        return
+    fi
+
+    profile_id=$("$WORKSPACE_SETUP_GSETTINGS" get org.gnome.Terminal.ProfilesList default | tr -d "'")
+    if [[ -z "$profile_id" ]]; then
+        echo "GNOME Terminal has no default profile; skipping its profile configuration"
+        return
+    fi
+
+    profile_schema="org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/:${profile_id}/"
+    current_font=$("$WORKSPACE_SETUP_GSETTINGS" get "$profile_schema" font | tr -d "'")
+    current_use_system_font=$("$WORKSPACE_SETUP_GSETTINGS" get "$profile_schema" use-system-font)
+
+    if [[ "$current_use_system_font" == "true" ]] && \
+       "$WORKSPACE_SETUP_GSETTINGS" list-schemas | grep -Fxq 'org.gnome.desktop.interface'; then
+        current_font=$("$WORKSPACE_SETUP_GSETTINGS" get \
+            org.gnome.desktop.interface monospace-font-name | tr -d "'")
+    fi
+    if [[ "$current_font" =~ ([0-9]+([.][0-9]+)?)$ ]]; then
+        font_size="${BASH_REMATCH[1]}"
+    fi
+    configured_font="$MESLO_NERD_FONT_FAMILY $font_size"
+
+    if [[ "$current_font" != "$configured_font" || "$current_use_system_font" != "false" ]]; then
+        profile_changed=1
+    fi
+
+    "$WORKSPACE_SETUP_GSETTINGS" set "$profile_schema" font "$configured_font"
+    "$WORKSPACE_SETUP_GSETTINGS" set "$profile_schema" use-system-font false
+
+    if [[ "$("$WORKSPACE_SETUP_GSETTINGS" get "$profile_schema" font)" != "'$configured_font'" ]] || \
+       [[ "$("$WORKSPACE_SETUP_GSETTINGS" get "$profile_schema" use-system-font)" != "false" ]]; then
+        echo "Failed to configure the GNOME Terminal font" >&2
+        return 1
+    fi
+
+    echo "GNOME Terminal default profile now uses $configured_font"
+    if [[ "${UBUNTU_TERMINAL_FONT_FILES_CHANGED:-0}" == "1" || "$profile_changed" == "1" ]] && \
+       "$WORKSPACE_SETUP_SYSTEMCTL" --user --quiet is-active gnome-terminal-server.service 2>/dev/null; then
+        UBUNTU_GNOME_TERMINAL_RESTART_REQUIRED=1
+        echo "IMPORTANT: GNOME Terminal is already running. Save your terminal work,"
+        echo "close every GNOME Terminal window, and relaunch it to load the new font."
     fi
 }
 
@@ -315,7 +457,7 @@ install_terminator() {
     foreground_color = "#839496"
     palette = "#073642:#dc322f:#859900:#b58900:#268bd2:#d33682:#2aa198:#eee8d5:#002b36:#cb4b16:#586e75:#657b83:#839496:#6c71c4:#93a1a1:#fdf6e3"
     use_system_font = False
-    font = MesloLGS NF 11
+    font = MesloLGS Nerd Font Mono 11
     scrollback_lines = 10000
 
 [layouts]

--- a/setup.sh
+++ b/setup.sh
@@ -72,7 +72,15 @@ run_step git            "Installing Git"                          install_git
 run_step gh             "Installing GitHub CLI"                   install_gh
 run_step zsh            "Installing Zsh"                          install_zsh
 run_step prezto         "Installing Prezto"                       install_prezto
-run_step fonts          "Installing Powerline Fonts"              install_powerline_fonts
+if [[ "$OS" == "ubuntu" ]]; then
+    # Reconcile this on every run. Older releases may have written a successful
+    # fonts marker without installing or selecting a usable terminal font.
+    echo ""
+    echo "=== Configuring Ubuntu terminal fonts ==="
+    configure_ubuntu_terminal_font
+else
+    run_step fonts      "Installing Powerline Fonts"              install_powerline_fonts
+fi
 run_step chrome         "Installing Chrome"                       install_chrome
 run_step obsidian       "Installing Obsidian"                     install_obsidian
 run_step zoom           "Installing Zoom"                         install_zoom
@@ -108,4 +116,10 @@ echo "=========================================="
 echo ""
 echo "Please log out and log back in for all changes to take effect."
 echo "After logging back in, open a new terminal to use zsh with Prezto."
+if [[ "$OS" == "ubuntu" && "${UBUNTU_GNOME_TERMINAL_RESTART_REQUIRED:-0}" == "1" ]]; then
+    echo ""
+    echo "IMPORTANT: Save your terminal work and close every GNOME Terminal"
+    echo "window before relaunching it. A new tab alone will reuse the old"
+    echo "terminal server and may keep the previous font loaded."
+fi
 echo ""

--- a/tests/ubuntu_terminal_font_integration_test.sh
+++ b/tests/ubuntu_terminal_font_integration_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/workspacesetup-font-integration.XXXXXX")
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+export HOME="$TEST_ROOT/home"
+
+# shellcheck source=../scripts/ubuntu.sh
+source "$REPO_DIR/scripts/ubuntu.sh"
+
+# The CI image already provides these dependencies. Avoid modifying the runner
+# while exercising the real pinned download, checksum, archive, and Fontconfig.
+sudo() { return 0; }
+
+install_powerline_fonts
+meslo_nerd_font_mono_installed
+
+for style in Regular Bold Italic BoldItalic; do
+    details=$("$WORKSPACE_SETUP_FC_SCAN" --format='%{family[0]}|%{spacing}' \
+        "$HOME/.local/share/fonts/MesloLGSNerdFontMono/MesloLGSNerdFontMono-${style}.ttf")
+    [[ "$details" == "$MESLO_NERD_FONT_FAMILY|100" ]]
+done
+
+for codepoint in e0a0 e0b0 e0b2 276f; do
+    details=$("$WORKSPACE_SETUP_FC_MATCH" --format='%{family[0]}|%{spacing}' \
+        "$MESLO_NERD_FONT_FAMILY:charset=$codepoint")
+    [[ "$details" == "$MESLO_NERD_FONT_FAMILY|100" ]]
+done
+
+echo "Ubuntu terminal font integration test passed"

--- a/tests/ubuntu_terminal_font_test.sh
+++ b/tests/ubuntu_terminal_font_test.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/workspacesetup-font-test.XXXXXX")
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+FAKE_BIN="$TEST_ROOT/fake-bin"
+BAD_PATH_BIN="$TEST_ROOT/bad-path-bin"
+FIXTURE_DIR="$TEST_ROOT/fixture"
+FIXTURE_ARCHIVE="$TEST_ROOT/Meslo.tar.xz"
+CURL_LOG="$TEST_ROOT/curl.log"
+GSETTINGS_LOG="$TEST_ROOT/gsettings.log"
+FONT_STATE="$TEST_ROOT/font.state"
+USE_SYSTEM_FONT_STATE="$TEST_ROOT/use-system-font.state"
+BAD_GSETTINGS_LOG="$TEST_ROOT/bad-gsettings.log"
+
+mkdir -p "$FAKE_BIN" "$BAD_PATH_BIN" "$FIXTURE_DIR"
+
+fixture_files=()
+for style in Regular Bold Italic BoldItalic; do
+    fixture_file="MesloLGSNerdFontMono-${style}.ttf"
+    printf 'fixture-%s\n' "$style" > "$FIXTURE_DIR/$fixture_file"
+    fixture_files+=("$fixture_file")
+done
+tar -cJf "$FIXTURE_ARCHIVE" -C "$FIXTURE_DIR" "${fixture_files[@]}"
+FIXTURE_SHA256=$(sha256sum "$FIXTURE_ARCHIVE" | awk '{print $1}')
+
+export FIXTURE_ARCHIVE CURL_LOG GSETTINGS_LOG FONT_STATE USE_SYSTEM_FONT_STATE
+
+cat > "$FAKE_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while (($#)); do
+    case "$1" in
+        --output)
+            output="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+cp "$FIXTURE_ARCHIVE" "$output"
+printf 'download\n' >> "$CURL_LOG"
+EOF
+
+cat > "$FAKE_BIN/fc-cache" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat > "$FAKE_BIN/fc-match" <<'EOF'
+#!/usr/bin/env bash
+printf 'MesloLGS Nerd Font Mono|100'
+EOF
+
+cat > "$FAKE_BIN/fc-scan" <<'EOF'
+#!/usr/bin/env bash
+font_file="${@: -1}"
+if grep -Fq 'corrupt' "$font_file"; then
+    exit 1
+fi
+printf 'MesloLGS Nerd Font Mono|100'
+EOF
+
+cat > "$FAKE_BIN/gsettings" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GSETTINGS_LOG"
+
+case "$1" in
+    list-schemas)
+        if [[ "${GSETTINGS_NO_TERMINAL_SCHEMA:-0}" == "1" ]]; then
+            printf '%s\n' org.gnome.desktop.interface
+        else
+            printf '%s\n' org.gnome.Terminal.ProfilesList org.gnome.desktop.interface
+        fi
+        ;;
+    get)
+        case "$2 $3" in
+            'org.gnome.Terminal.ProfilesList default')
+                printf "'test-profile'\n"
+                ;;
+            'org.gnome.desktop.interface monospace-font-name')
+                printf "'Ubuntu Sans Mono 13'\n"
+                ;;
+            *' font')
+                if [[ -f "$FONT_STATE" ]]; then
+                    cat "$FONT_STATE"
+                else
+                    printf "'Monospace 12'\n"
+                fi
+                ;;
+            *' use-system-font')
+                if [[ -f "$USE_SYSTEM_FONT_STATE" ]]; then
+                    cat "$USE_SYSTEM_FONT_STATE"
+                else
+                    printf 'true\n'
+                fi
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+        ;;
+    set)
+        case "$3" in
+            font)
+                printf "'%s'\n" "$4" > "$FONT_STATE"
+                ;;
+            use-system-font)
+                printf '%s\n' "$4" > "$USE_SYSTEM_FONT_STATE"
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+
+cat > "$FAKE_BIN/systemctl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat > "$BAD_PATH_BIN/gsettings" <<EOF
+#!/usr/bin/env bash
+printf 'called\n' >> '$BAD_GSETTINGS_LOG'
+exit 99
+EOF
+
+chmod +x "$FAKE_BIN"/* "$BAD_PATH_BIN/gsettings"
+
+export PATH="$BAD_PATH_BIN:$FAKE_BIN:$PATH"
+export HOME="$TEST_ROOT/home"
+
+# Production defaults must use Ubuntu's system binaries even if Homebrew (or
+# another toolchain) puts incompatible commands earlier in PATH.
+(
+    unset WORKSPACE_SETUP_FC_CACHE WORKSPACE_SETUP_FC_MATCH WORKSPACE_SETUP_FC_SCAN
+    unset WORKSPACE_SETUP_GSETTINGS WORKSPACE_SETUP_SYSTEMCTL
+    # shellcheck source=../scripts/ubuntu.sh
+    source "$REPO_DIR/scripts/ubuntu.sh"
+    [[ "$WORKSPACE_SETUP_FC_CACHE" == "/usr/bin/fc-cache" ]]
+    [[ "$WORKSPACE_SETUP_FC_MATCH" == "/usr/bin/fc-match" ]]
+    [[ "$WORKSPACE_SETUP_FC_SCAN" == "/usr/bin/fc-scan" ]]
+    [[ "$WORKSPACE_SETUP_GSETTINGS" == "/usr/bin/gsettings" ]]
+)
+
+export WORKSPACE_SETUP_FC_CACHE="$FAKE_BIN/fc-cache"
+export WORKSPACE_SETUP_FC_MATCH="$FAKE_BIN/fc-match"
+export WORKSPACE_SETUP_FC_SCAN="$FAKE_BIN/fc-scan"
+export WORKSPACE_SETUP_GSETTINGS="$FAKE_BIN/gsettings"
+export WORKSPACE_SETUP_SYSTEMCTL="$FAKE_BIN/systemctl"
+
+# shellcheck source=../scripts/ubuntu.sh
+source "$REPO_DIR/scripts/ubuntu.sh"
+MESLO_NERD_FONT_ARCHIVE_SHA256="$FIXTURE_SHA256"
+sudo() { return 0; }
+
+start_dir=$PWD
+install_powerline_fonts
+[[ "$PWD" == "$start_dir" ]]
+meslo_nerd_font_mono_installed
+[[ "$(wc -l < "$CURL_LOG")" == "1" ]]
+
+for style in Regular Bold Italic BoldItalic; do
+    test -s "$HOME/.local/share/fonts/MesloLGSNerdFontMono/MesloLGSNerdFontMono-${style}.ttf"
+done
+
+# A completed install is a no-op, while a missing face triggers a repair.
+install_powerline_fonts
+[[ "$(wc -l < "$CURL_LOG")" == "1" ]]
+printf 'corrupt\n' \
+    > "$HOME/.local/share/fonts/MesloLGSNerdFontMono/MesloLGSNerdFontMono-BoldItalic.ttf"
+install_powerline_fonts
+[[ "$(wc -l < "$CURL_LOG")" == "2" ]]
+
+# A bad checksum must fail before any font files are installed.
+export HOME="$TEST_ROOT/bad-checksum-home"
+MESLO_NERD_FONT_ARCHIVE_SHA256=$(printf '0%.0s' {1..64})
+if install_powerline_fonts; then
+    echo "checksum failure was incorrectly accepted" >&2
+    exit 1
+fi
+[[ ! -d "$HOME/.local/share/fonts/MesloLGSNerdFontMono" ]]
+
+# Configure the default GNOME Terminal profile with the exact Mono family and
+# preserve the current desktop font size. A fake PATH gsettings must not run.
+export HOME="$TEST_ROOT/home"
+MESLO_NERD_FONT_ARCHIVE_SHA256="$FIXTURE_SHA256"
+export DBUS_SESSION_BUS_ADDRESS='unix:path=/tmp/test-session-bus'
+export WAYLAND_DISPLAY='wayland-test'
+rm -f "$FONT_STATE" "$USE_SYSTEM_FONT_STATE"
+mkdir -p "$HOME/.config/terminator"
+printf '[profiles]\n    font = MesloLGS NF 11\n' > "$HOME/.config/terminator/config"
+unset UBUNTU_GNOME_TERMINAL_RESTART_REQUIRED
+configure_ubuntu_terminal_font
+grep -Fxq "'MesloLGS Nerd Font Mono 13'" "$FONT_STATE"
+grep -Fxq 'false' "$USE_SYSTEM_FONT_STATE"
+grep -Fxq '    font = MesloLGS Nerd Font Mono 11' "$HOME/.config/terminator/config"
+[[ "${UBUNTU_GNOME_TERMINAL_RESTART_REQUIRED:-0}" == "1" ]]
+[[ ! -e "$BAD_GSETTINGS_LOG" ]]
+grep -Fq 'set org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/:test-profile/ font MesloLGS Nerd Font Mono 13' \
+    "$GSETTINGS_LOG"
+grep -Fq 'set org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/:test-profile/ use-system-font false' \
+    "$GSETTINGS_LOG"
+
+# An already-correct profile should not request another restart.
+unset UBUNTU_GNOME_TERMINAL_RESTART_REQUIRED UBUNTU_TERMINAL_FONT_FILES_CHANGED
+configure_ubuntu_terminal_font
+[[ "${UBUNTU_GNOME_TERMINAL_RESTART_REQUIRED:-0}" == "0" ]]
+
+# Font installation remains useful on headless Ubuntu, but GUI configuration
+# must be skipped without a local display or while connected over SSH.
+gsettings_calls_before=$(wc -l < "$GSETTINGS_LOG")
+unset WAYLAND_DISPLAY DISPLAY
+configure_ubuntu_terminal_font
+[[ "$(wc -l < "$GSETTINGS_LOG")" == "$gsettings_calls_before" ]]
+export DISPLAY=':0' SSH_CONNECTION='example'
+configure_ubuntu_terminal_font
+[[ "$(wc -l < "$GSETTINGS_LOG")" == "$gsettings_calls_before" ]]
+unset SSH_CONNECTION
+
+# A desktop without GNOME Terminal should be a clean no-op.
+export GSETTINGS_NO_TERMINAL_SCHEMA=1
+configure_ubuntu_terminal_font
+[[ ! -e "$BAD_GSETTINGS_LOG" ]]
+unset GSETTINGS_NO_TERMINAL_SCHEMA DISPLAY DBUS_SESSION_BUS_ADDRESS
+
+# Never overwrite a user-selected Terminator font.
+printf '[profiles]\n    font = Custom Mono 14\n' > "$HOME/.config/terminator/config"
+migrate_terminator_font_name
+grep -Fxq '    font = Custom Mono 14' "$HOME/.config/terminator/config"
+
+echo "Ubuntu terminal font tests passed"


### PR DESCRIPTION
## Summary

- Replace the Ubuntu partial Powerline/Meslo setup with the pinned official MesloLGS Nerd Font Mono v3.5.0 archive and checksum verification.
- Validate all four monospaced faces and the Prezto Powerline glyphs with the Ubuntu system Fontconfig.
- Configure the default GNOME Terminal profile with the exact font family while preserving its point size.
- Migrate the generated Terminator setting, repair installs hidden by legacy markers, and skip GNOME writes over SSH or in headless sessions.
- Warn users to close every GNOME Terminal window after a font change so the persistent terminal server reloads its font map.
- Add mocked regression coverage and a real archive/Fontconfig integration test on Ubuntu 24.04.

## Root cause

Ubuntu installed an ambiguous non-Mono Meslo family but did not select it in GNOME Terminal. The Prezto Paradox prompt uses Powerline private-use glyphs, so GNOME fell back to unrelated fonts. Homebrew binaries earlier in PATH and the persistent GNOME Terminal server made the failure harder to detect and could leave extreme character spacing after a font change.

## Impact

This change is Ubuntu-only. The macOS and Amazon Linux setup paths are unchanged. Existing custom Terminator fonts are preserved; only the exact legacy generated value is migrated.

## Checks

- `bash -n setup.sh scripts/*.sh tests/*.sh`
- `bash tests/ubuntu_terminal_font_test.sh`
- `bash tests/ubuntu_terminal_font_integration_test.sh`
- `git diff --check`